### PR TITLE
Removed binary_to_list/1 and list_to_binary/1 deprecated warnings.

### DIFF
--- a/lib/hex.ex
+++ b/lib/hex.ex
@@ -21,12 +21,12 @@ defmodule Hex do
   """
   def encode(str) when is_binary(str) do
     binary_to_hex_list(str)
-    |> list_to_binary
+    |> iolist_to_binary
   end
 
   def encode(str) when is_list(str) do
     list_to_hex(str)
-    |> list_to_binary
+    |> iolist_to_binary
   end
 
   def encode(int) when is_integer(int) do
@@ -74,14 +74,14 @@ defmodule Hex do
       "This is a test."
   """
   def decode(hex_str) when is_binary(hex_str) do
-    binary_to_list(hex_str)
+    :binary.bin_to_list(hex_str)
     |> hex_str_to_list
-    |> list_to_binary
+    |> iolist_to_binary
   end
 
   def decode(hex_str) when is_list(hex_str) do
     hex_str_to_list(hex_str)
-    |> list_to_binary
+    |> iolist_to_binary
   end
 
   @doc """
@@ -97,7 +97,7 @@ defmodule Hex do
       'This is a test.'
   """
   def decode_to_list(hex_str) when is_binary(hex_str) do
-    binary_to_list(hex_str)
+    :binary.bin_to_list(hex_str)
     |> hex_str_to_list
   end
 
@@ -126,7 +126,7 @@ defmodule Hex do
   end
 
   defp binary_to_hex_list(str) do
-    binary_to_list(str)
+    :binary.bin_to_list(str)
     |> list_to_hex
   end
 


### PR DESCRIPTION
Replaced list_to_binary with iolist_to_binary and binary_to_list with :binary.bin_to_list
