### PR TITLE
Allow newer Elixir version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Hex.Mixfile do
   def project do
     [ app: :hex,
       version: "0.4.0",
-      elixir: "~> 0.12.0",
+      elixir: ">= 0.12.0",
       deps: deps ]
   end
 


### PR DESCRIPTION
Tests all pass on Elixir 0.13.0.
