### PR TITLE
Can now pad a hex encode to a set number of digits

### DIFF
--- a/lib/hex.ex
+++ b/lib/hex.ex
@@ -18,6 +18,9 @@ defmodule Hex do
 
       iex> Hex.encode(123456)
       "1e240"
+
+      iex> Hex.encode(15, 4)
+      "000f"
   """
   def encode(str) when is_binary(str) do
     binary_to_hex_list(str)
@@ -32,6 +35,12 @@ defmodule Hex do
   def encode(int) when is_integer(int) do
     Integer.to_string(int, 16)
     |> String.downcase
+  end
+
+  def encode(int, digits) when is_integer(int) do
+    Integer.to_string(int, 16)
+    |> String.downcase
+    |> String.rjust(digits, ?0)
   end
 
   @doc """

--- a/test/hex_test.exs
+++ b/test/hex_test.exs
@@ -5,6 +5,10 @@ defmodule HexTest do
 
   doctest Hex
 
+  test "encodes an integer to hex string with padding" do
+    assert Hex.encode(15, 4) == "000f"
+  end
+
   test "encodes a binary to a hex binary" do
     assert Hex.encode("This is a test.") == "54686973206973206120746573742e"
   end


### PR DESCRIPTION
I added a convenience method to specify the number of digits to be returned in `Hex.encode/2`
This is convenient for generating HTML hex color codes.

Now it's easy to convert like so:

```
iex> Hex.encode(15, 2)
"0f"
```

instead of getting just `f`.
