### PR TITLE
Updated Elixir version to 1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: elixir
-elixir: 1.2.0
+elixir: 1.3.0
 otp_release:
   - 18.1
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+**0.6.0**
+* Made more consistent use of terms 'char-list' and 'string (binary)'.
+* bumped elixir version to 1.0 or greater
+
 **0.5.1**
 * Add ex_doc docs
 * Version bump for hex.pm publishing

--- a/README.md
+++ b/README.md
@@ -19,18 +19,20 @@ If you really *must* use the old version, it's on the branch `pre-rename-to-hexa
 ```elixir
 defp deps do
   [
-    {:hexate,  ">= 0.5.0"}
+    {:hexate,  ">= 0.6.0"}
   ]
 end
 ```
 
 ## Usage
 
-Encode to binary string:
+Encode to string (binary):
 ```elixir
+# From a string
 iex> Hexate.encode("This is a test.")
      "54686973206973206120746573742e"
 
+# From a char-list
 iex> Hexate.encode('This is a test.')
      "54686973206973206120746573742e"
 
@@ -47,42 +49,50 @@ iex> Hexate.encode(15.0)
      "f"
 ```
 
-Decode to binary string:
+Decode to string (binary):
 ```elixir
+# From a hex string
 iex> Hexate.decode("54686973206973206120746573742e")
      "This is a test."
 
+# From a hex char-list
 iex> Hexate.decode('54686973206973206120746573742e')
      "This is a test."
 ```
 
-Encode to list:
+Encode to hex char-list:
 ```elixir
+# From a unicode char-list
 iex> Hexate.encode_to_list('This is a test.')
      '54686973206973206120746573742e'
 
+# From a unicode string
 iex> Hexate.encode_to_list("This is a test.")
      '54686973206973206120746573742e'
 
+# From an integer
 iex> Hexate.encode_to_list(123456)
      '1e240'
-
 ```
 
-Decode to list:
+Decode to unicode char-list:
 ```elixir
+# From a hex char-list
 iex> Hexate.decode_to_list('54686973206973206120746573742e')
      'This is a test.'
 
+# From a hex string
 iex> Hexate.decode_to_list("54686973206973206120746573742e")
      'This is a test.'
 ```
 
-Convert hexate to integer:
+Convert hex to integer:
 ```elixir
+# From hex char-list
 iex> Hexate.to_integer('54686973206973206120746573742e')
      438270661302729020147902120434299950
 
+# From hex string
 iex> Hexate.to_integer("54686973206973206120746573742e")
      438270661302729020147902120434299950
 ```

--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ iex> Hexate.to_integer("54686973206973206120746573742e")
 * Make a feature branch
 * Issue a pull request
 
+## Running tests
+
+```bash
+mix deps.get
+mix test.watch
+```
+
 ## Authors
 
 [Robert J Samson](https://github.com/rjsamson)

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,5 @@
+use Mix.Config
+
+if Mix.env == :dev do
+  config :mix_test_watch, tasks: ~w(test dogma), clear: true
+end

--- a/doc/404.html
+++ b/doc/404.html
@@ -5,7 +5,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="generator" content="ExDoc v0.11.4">
-    <title>404 – hexate v0.5.1</title>
+    <title>404 – hexate v0.6.0</title>
     <link rel="stylesheet" href="dist/app-1e374caa3d.css" />
     <script src="dist/sidebar_items.js"></script>
   </head>
@@ -27,7 +27,7 @@
         hexate
       </h1>
       <h2 class="sidebar-projectVersion">
-        v0.5.1
+        v0.6.0
       </h2>
     </div>
     

--- a/doc/Hexate.html
+++ b/doc/Hexate.html
@@ -5,7 +5,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="generator" content="ExDoc v0.11.4">
-    <title>Hexate – hexate v0.5.1</title>
+    <title>Hexate – hexate v0.6.0</title>
     <link rel="stylesheet" href="dist/app-1e374caa3d.css" />
     <script src="dist/sidebar_items.js"></script>
   </head>
@@ -27,7 +27,7 @@
         hexate
       </h1>
       <h2 class="sidebar-projectVersion">
-        v0.5.1
+        v0.6.0
       </h2>
     </div>
     
@@ -59,7 +59,7 @@
 
 
       <h1>
-        <small class="visible-xs">hexate v0.5.1</small>
+        <small class="visible-xs">hexate v0.6.0</small>
         Hexate
         
         
@@ -68,7 +68,7 @@
       
         <section id="moduledoc" class="docstring">
           <p>A simple module to convert to and from hex encoded strings.</p>
-<p>Encodes / decodes both lists and binaries.</p>
+<p>Encodes / decodes both char-lists and strings.</p>
 
         </section>
       
@@ -93,8 +93,8 @@
     <a href="#decode/1">decode(hex_str)</a>
   </div>
   
-    <div class="summary-synopsis"><p>Returns a decoded binary from a hex string in either list
-or binary form</p>
+    <div class="summary-synopsis"><p>Returns a decoded binary from a hex string in either char-list
+or string form</p>
 </div>
   
 </div>
@@ -103,8 +103,8 @@ or binary form</p>
     <a href="#decode_to_list/1">decode_to_list(hex_str)</a>
   </div>
   
-    <div class="summary-synopsis"><p>Returns a decoded list from a hex string in either list
-or binary form</p>
+    <div class="summary-synopsis"><p>Returns a decoded char-list from a hex string in either char-list
+or string form</p>
 </div>
   
 </div>
@@ -113,7 +113,7 @@ or binary form</p>
     <a href="#encode/2">encode(int, digits \\ 1)</a>
   </div>
   
-    <div class="summary-synopsis"><p>Returns a hex encoded binary from a list, binary or integer</p>
+    <div class="summary-synopsis"><p>Returns a hex encoded string from a char-list, string or integer</p>
 </div>
   
 </div>
@@ -122,7 +122,7 @@ or binary form</p>
     <a href="#encode_to_list/1">encode_to_list(str)</a>
   </div>
   
-    <div class="summary-synopsis"><p>Returns a hex encoded list from a list, binary or integer</p>
+    <div class="summary-synopsis"><p>Returns a hex encoded list from a char-list, string or integer</p>
 </div>
   
 </div>
@@ -132,7 +132,7 @@ or binary form</p>
   </div>
   
     <div class="summary-synopsis"><p>Returns an integer representation of a given string of hex,
-taking a list or a binary as an argument</p>
+taking a char-list or a string as an argument</p>
 </div>
   
 </div>
@@ -167,8 +167,8 @@ taking a list or a binary as an argument</p>
   </div>
   
   <section class="docstring">
-    <p>Returns a decoded binary from a hex string in either list
-or binary form.</p>
+    <p>Returns a decoded binary from a hex string in either char-list
+or string form.</p>
 <h2>Examples</h2>
 <pre><code class="iex elixir">iex&gt; Hexate.decode(&quot;54686973206973206120746573742e&quot;)
 &quot;This is a test.&quot;
@@ -188,8 +188,8 @@ iex&gt; Hexate.decode(&#39;54686973206973206120746573742e&#39;)
   </div>
   
   <section class="docstring">
-    <p>Returns a decoded list from a hex string in either list
-or binary form.</p>
+    <p>Returns a decoded char-list from a hex string in either char-list
+or string form.</p>
 <h2>Examples</h2>
 <pre><code class="iex elixir">iex&gt; Hexate.decode_to_list(&quot;54686973206973206120746573742e&quot;)
 &#39;This is a test.&#39;
@@ -209,7 +209,7 @@ iex&gt; Hexate.decode_to_list(&#39;54686973206973206120746573742e&#39;)
   </div>
   
   <section class="docstring">
-    <p>Returns a hex encoded binary from a list, binary or integer.</p>
+    <p>Returns a hex encoded string from a char-list, string or integer.</p>
 <h2>Examples</h2>
 <pre><code class="iex elixir">iex&gt; Hexate.encode(&quot;This is a test.&quot;)
 &quot;54686973206973206120746573742e&quot;
@@ -241,7 +241,7 @@ iex&gt; Hexate.encode(15.0)
   </div>
   
   <section class="docstring">
-    <p>Returns a hex encoded list from a list, binary or integer.</p>
+    <p>Returns a hex encoded list from a char-list, string or integer.</p>
 <h2>Examples</h2>
 <pre><code class="iex elixir">iex&gt; Hexate.encode_to_list(&quot;This is a test.&quot;)
 &#39;54686973206973206120746573742e&#39;
@@ -265,7 +265,7 @@ iex&gt; Hexate.encode_to_list(123456)
   
   <section class="docstring">
     <p>Returns an integer representation of a given string of hex,
-taking a list or a binary as an argument.</p>
+taking a char-list or a string as an argument.</p>
 <h2>Examples</h2>
 <pre><code class="iex elixir">iex&gt; Hexate.to_integer(&#39;54686973206973206120746573742e&#39;)
 438270661302729020147902120434299950

--- a/doc/api-reference.html
+++ b/doc/api-reference.html
@@ -5,7 +5,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="generator" content="ExDoc v0.11.4">
-    <title>API Reference – hexate v0.5.1</title>
+    <title>API Reference – hexate v0.6.0</title>
     <link rel="stylesheet" href="dist/app-1e374caa3d.css" />
     <script src="dist/sidebar_items.js"></script>
   </head>
@@ -27,7 +27,7 @@
         hexate
       </h1>
       <h2 class="sidebar-projectVersion">
-        v0.5.1
+        v0.6.0
       </h2>
     </div>
     
@@ -58,7 +58,7 @@
   <div id="content" class="content-inner">
 
   <h1>
-    <small class="visible-xs">hexate v0.5.1</small>
+    <small class="visible-xs">hexate v0.6.0</small>
     API Reference
   </h1>
 

--- a/doc/index.html
+++ b/doc/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>hexate v0.5.1 – Documentation</title>
+    <title>hexate v0.6.0 – Documentation</title>
     <meta http-equiv="refresh" content="0; url=api-reference.html">
     <meta name="robots" content="noindex">
     <meta name="generator" content="ExDoc v0.11.4">

--- a/lib/hexate.ex
+++ b/lib/hexate.ex
@@ -31,7 +31,8 @@ defmodule Hexate do
   def encode(int, digits \\ 1)
 
   def encode(int, digits) when is_integer(int) do
-    Integer.to_string(int, 16)
+    int
+    |> Integer.to_string(16)
     |> String.downcase
     |> String.rjust(digits, ?0)
   end
@@ -41,12 +42,14 @@ defmodule Hexate do
   end
 
   def encode(str, _digits) when is_binary(str) do
-    binary_to_hex_list(str)
+    str
+    |> binary_to_hex_list
     |> IO.iodata_to_binary
   end
 
   def encode(str, _digits) when is_list(str) do
-    list_to_hex(str)
+    str
+    |> list_to_hex
     |> IO.iodata_to_binary
   end
 
@@ -73,7 +76,8 @@ defmodule Hexate do
   end
 
   def encode_to_list(int) when is_integer(int) do
-    Integer.to_char_list(int, 16)
+    int
+    |> Integer.to_char_list(16)
     |> :string.to_lower
   end
 
@@ -90,13 +94,15 @@ defmodule Hexate do
       "This is a test."
   """
   def decode(hex_str) when is_binary(hex_str) do
-    :binary.bin_to_list(hex_str)
+    hex_str
+    |> :binary.bin_to_list
     |> hex_str_to_list
     |> IO.iodata_to_binary
   end
 
   def decode(hex_str) when is_list(hex_str) do
-    hex_str_to_list(hex_str)
+    hex_str
+    |> hex_str_to_list
     |> IO.iodata_to_binary
   end
 
@@ -113,7 +119,8 @@ defmodule Hexate do
       'This is a test.'
   """
   def decode_to_list(hex_str) when is_binary(hex_str) do
-    :binary.bin_to_list(hex_str)
+    hex_str
+    |> :binary.bin_to_list
     |> hex_str_to_list
   end
 
@@ -142,7 +149,8 @@ defmodule Hexate do
   end
 
   defp binary_to_hex_list(str) do
-    :binary.bin_to_list(str)
+    str
+    |> :binary.bin_to_list
     |> list_to_hex
   end
 

--- a/lib/hexate.ex
+++ b/lib/hexate.ex
@@ -2,11 +2,11 @@ defmodule Hexate do
   @moduledoc """
   A simple module to convert to and from hex encoded strings.
 
-  Encodes / decodes both lists and binaries.
+  Encodes / decodes both char-lists and strings.
   """
 
   @doc """
-  Returns a hex encoded binary from a list, binary or integer.
+  Returns a hex encoded string from a char-list, string or integer.
 
   ## Examples
 
@@ -51,7 +51,7 @@ defmodule Hexate do
   end
 
   @doc """
-  Returns a hex encoded list from a list, binary or integer.
+  Returns a hex encoded list from a char-list, string or integer.
 
   ## Examples
 
@@ -78,8 +78,8 @@ defmodule Hexate do
   end
 
   @doc """
-  Returns a decoded binary from a hex string in either list
-  or binary form.
+  Returns a decoded binary from a hex string in either char-list
+  or string form.
 
   ## Examples
 
@@ -101,8 +101,8 @@ defmodule Hexate do
   end
 
   @doc """
-  Returns a decoded list from a hex string in either list
-  or binary form.
+  Returns a decoded char-list from a hex string in either char-list
+  or string form.
 
   ## Examples
 
@@ -123,7 +123,7 @@ defmodule Hexate do
 
   @doc """
   Returns an integer representation of a given string of hex,
-  taking a list or a binary as an argument.
+  taking a char-list or a string as an argument.
 
   ## Examples
 
@@ -150,7 +150,7 @@ defmodule Hexate do
     []
   end
 
-  defp hex_str_to_list([x,y|tail]) do
+  defp hex_str_to_list([x, y | tail]) do
     [to_int(x) * 16 + to_int(y) | hex_str_to_list(tail)]
   end
 
@@ -158,7 +158,7 @@ defmodule Hexate do
     []
   end
 
-  defp list_to_hex([head|tail]) do
+  defp list_to_hex([head | tail]) do
     to_hex_str(head) ++ list_to_hex(tail)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,9 +4,10 @@ defmodule Hexate.Mixfile do
   def project do
     [ app: :hexate,
       version: "0.6.0",
-      elixir: ">= 1.0.0",
+      elixir: "~> 1.3",
+      build_embedded: Mix.env == :prod,
+      start_permanent: Mix.env == :prod,
       description: description,
-      package: package,
       deps: deps ]
   end
 
@@ -27,11 +28,16 @@ defmodule Hexate.Mixfile do
   end
 
   def application do
-    []
+    [applications: [:logger]]
   end
 
   defp deps do
-    [{:earmark, "~> 0.1", only: :dev},
-     {:ex_doc, "~> 0.11", only: :dev}]
+    [
+      {:mix_test_watch, "~> 0.2", only: :dev},
+      {:dogma, "~> 0.1", only: [:dev, :test]},
+      {:ex_unit_notifier, "~> 0.1", only: :test},
+      {:earmark, "~> 0.1", only: :dev},
+      {:ex_doc, "~> 0.11", only: :dev}
+    ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -8,6 +8,7 @@ defmodule Hexate.Mixfile do
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       description: description,
+      package: package,
       deps: deps ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,8 +3,8 @@ defmodule Hexate.Mixfile do
 
   def project do
     [ app: :hexate,
-      version: "0.5.1",
-      elixir: ">= 0.15.1",
+      version: "0.6.0",
+      elixir: ">= 1.0.0",
       description: description,
       package: package,
       deps: deps ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
-%{"earmark": {:hex, :earmark, "0.2.1"},
-  "ex_doc": {:hex, :ex_doc, "0.11.4"}}
+%{"earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.11.4", "a064bdb720594c3745b94709b17ffb834fd858b4e0c1f48f37c0d92700759e02", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,7 @@
-%{"earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.11.4", "a064bdb720594c3745b94709b17ffb834fd858b4e0c1f48f37c0d92700759e02", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]}}
+%{"dogma": {:hex, :dogma, "0.1.7", "927f76a89a809db96e0983b922fc899f601352690aefa123529b8aa0c45123b2", [:mix], [{:poison, ">= 1.0.0", [hex: :poison, optional: false]}]},
+  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.11.4", "a064bdb720594c3745b94709b17ffb834fd858b4e0c1f48f37c0d92700759e02", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+  "ex_unit_notifier": {:hex, :ex_unit_notifier, "0.1.1", "53d4d3a351d77f3d73e39aa04a59bd70bcfd16cae0d19a64b3bcda0a36703b6f", [:mix], []},
+  "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
+  "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
+  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []}}

--- a/package.exs
+++ b/package.exs
@@ -1,6 +1,6 @@
 Expm.Package.new(name: "hexate",
   description: "A simple module for encoding and decoding hex strings in Elixir.",
-  version: "0.5.1", keywords: [],
+  version: "0.6.0", keywords: [],
   maintainers: [
     [name: "Rob Samson",  email: "rjsamson@me.com"]
     [name: "David Parry", email: "david.parry@suranyami.com"]

--- a/package.exs
+++ b/package.exs
@@ -1,8 +1,8 @@
 Expm.Package.new(name: "hexate",
-  description: "A simple module for encoding and decoding hex strings in Elixir.",
+  description: "A simple module for encoding & decoding hex strings in Elixir.",
   version: "0.6.0", keywords: [],
   maintainers: [
-    [name: "Rob Samson",  email: "rjsamson@me.com"]
+    [name: "Rob Samson",  email: "rjsamson@me.com"],
     [name: "David Parry", email: "david.parry@suranyami.com"]
   ],
   repositories: [[github: "rjsamson/hexate"]])

--- a/test/hexate_test.exs
+++ b/test/hexate_test.exs
@@ -2,7 +2,6 @@ Code.require_file "test_helper.exs", __DIR__
 
 defmodule HexateTest do
   use ExUnit.Case
-
   doctest Hexate
 
   test "encodes an integer to hex string with padding" do
@@ -26,27 +25,33 @@ defmodule HexateTest do
   end
 
   test "encodes a char-list to a hex char-list" do
-    assert Hexate.encode_to_list('This is a test.') == '54686973206973206120746573742e'
+    assert Hexate.encode_to_list('This is a test.') ==
+      '54686973206973206120746573742e'
   end
 
   test "encodes a unicode string to a hex char-list" do
-    assert Hexate.encode_to_list("This is a test.") == '54686973206973206120746573742e'
+    assert Hexate.encode_to_list("This is a test.") ==
+      '54686973206973206120746573742e'
   end
 
   test "decodes to a unicode char-list from a hex char-list" do
-    assert Hexate.decode_to_list('54686973206973206120746573742e') == 'This is a test.'
+    assert Hexate.decode_to_list('54686973206973206120746573742e') ==
+      'This is a test.'
   end
 
  test "decodes to a unicode char-list from a hex string" do
-    assert Hexate.decode_to_list("54686973206973206120746573742e") == 'This is a test.'
+    assert Hexate.decode_to_list("54686973206973206120746573742e") ==
+      'This is a test.'
   end
 
   test "converts hex char-list to an integer" do
-    assert Hexate.to_integer('54686973206973206120746573742e') == 438270661302729020147902120434299950
+    assert Hexate.to_integer('54686973206973206120746573742e') ==
+      438270661302729020147902120434299950
   end
 
   test "converts hex string to an integer" do
-    assert Hexate.to_integer("54686973206973206120746573742e") == 438270661302729020147902120434299950
+    assert Hexate.to_integer("54686973206973206120746573742e") ==
+      438270661302729020147902120434299950
   end
 
   test "converts an integer to a hex string" do

--- a/test/hexate_test.exs
+++ b/test/hexate_test.exs
@@ -9,51 +9,51 @@ defmodule HexateTest do
     assert Hexate.encode(15, 4) == "000f"
   end
 
-  test "encodes a binary to a hex binary" do
+  test "encodes a string to a hex binary" do
     assert Hexate.encode("This is a test.") == "54686973206973206120746573742e"
   end
 
-  test "encodes a list to a hex binary" do
+  test "encodes a char-list to a hex binary" do
     assert Hexate.encode('This is a test.') == "54686973206973206120746573742e"
   end
 
-  test "decodes to a binary from a hex binary" do
+  test "decodes to a unicode string from a hex string" do
     assert Hexate.decode("54686973206973206120746573742e") == "This is a test."
   end
 
-  test "decodes to a binary from a hex list" do
+  test "decodes to a unicode string from a hex char-list" do
     assert Hexate.decode('54686973206973206120746573742e') == "This is a test."
   end
 
-  test "encodes a list to a hex list" do
+  test "encodes a char-list to a hex char-list" do
     assert Hexate.encode_to_list('This is a test.') == '54686973206973206120746573742e'
   end
 
-  test "encodes a binary to a hex list" do
+  test "encodes a unicode string to a hex char-list" do
     assert Hexate.encode_to_list("This is a test.") == '54686973206973206120746573742e'
   end
 
-  test "decodes to a list from a hex list" do
+  test "decodes to a unicode char-list from a hex char-list" do
     assert Hexate.decode_to_list('54686973206973206120746573742e') == 'This is a test.'
   end
 
- test "decodes to a list from a hex binary" do
+ test "decodes to a unicode char-list from a hex string" do
     assert Hexate.decode_to_list("54686973206973206120746573742e") == 'This is a test.'
   end
 
-  test "converts hex list to an integer" do
+  test "converts hex char-list to an integer" do
     assert Hexate.to_integer('54686973206973206120746573742e') == 438270661302729020147902120434299950
   end
 
-  test "converts hex binary to an integer" do
+  test "converts hex string to an integer" do
     assert Hexate.to_integer("54686973206973206120746573742e") == 438270661302729020147902120434299950
   end
 
-  test "converts an integer to a hex binary" do
+  test "converts an integer to a hex string" do
     assert Hexate.encode(123456) == "1e240"
   end
 
-  test "converts an integer to a hex list" do
+  test "converts an integer to a hex char-list" do
     assert Hexate.encode_to_list(123456) == '1e240'
   end
 end


### PR DESCRIPTION
* Elixir version 1.x requirement now.
* Updated package structure to be more like current practice.
* Added handy dev tools: `mix_test_watch`, `dogma`, `ex_unit_notifier`.
* Ran `dogma` linter over code and cleaned up as suggested.